### PR TITLE
Fix Invalid access

### DIFF
--- a/addons/SliderLabel/SliderLabel.gd
+++ b/addons/SliderLabel/SliderLabel.gd
@@ -79,6 +79,9 @@ func _update_label():
 	if not is_visible_in_tree():
 		return
 	
+	if not slider:
+		return  # If the slider is not ready yet, cancel
+
 	if custom_format.is_empty():
 		text = str(slider.value)
 	else:


### PR DESCRIPTION
Added check if slider is ready to prevent this error: res://addons/SliderLabel/SliderLabel.gd:86 - Invalid access to property or key 'value' on a base object of type 'Nil'.